### PR TITLE
feat: upgrade to typescript 3.0+

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "prettier": "^1.7.4",
-    "typescript": "^2.5.3"
+    "typescript": "^2.5.3 || ^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
To remove the warning for TS 3.0+ users, I added `|| ^3.0.0` to the `typescript` version in the `peerDependencies`. 🎉 

Closes #18 #22 #23